### PR TITLE
PT-1193 - Add Gatekeeper missing route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Go-Common is the library of common functions for Tidepool's Go-based applications
 
+## 0.5.0 - 2020-04-14
+### Added
+- Complete Getekeeper client with missing route
+
 ## 0.4.0 - 2019-10-17
 ### Changed
 - PT-1201 Add new configuration item “skipHighwater”

--- a/clients/mocks.go
+++ b/clients/mocks.go
@@ -51,7 +51,7 @@ func (mock *GatekeeperMock) GroupsForUser(userID string) (UsersPermissions, erro
 }
 
 func (mock *GatekeeperMock) SetPermissions(userID, groupID string, permissions Permissions) (Permissions, error) {
-	return Permissions{userID: Allowed}, nil
+	return Permissions{"root": Allowed}, nil
 }
 
 //A mock of the Seagull interface

--- a/clients/mocks.go
+++ b/clients/mocks.go
@@ -40,9 +40,10 @@ func (mock *GatekeeperMock) GroupsForUser(userID string) (UsersPermissions, erro
 	if mock.expectedPermissions != nil || mock.expectedError != nil {
 		if len(mock.UserIDs) > 0 {
 			perms := make(map[string]Permissions)
-			for _, userID := range mock.UserIDs {
-				perms[userID] = mock.expectedPermissions
+			for _, user := range mock.UserIDs {
+				perms[user] = mock.expectedPermissions
 			}
+			perms[userID] = Permissions{"root": Allowed}
 			return perms, mock.expectedError
 		}
 		return UsersPermissions{userID: mock.expectedPermissions}, mock.expectedError

--- a/clients/mocks.go
+++ b/clients/mocks.go
@@ -33,6 +33,13 @@ func (mock *GatekeeperMock) UsersInGroup(groupID string) (UsersPermissions, erro
 	}
 }
 
+func (mock *GatekeeperMock) GroupsForUser(userID string) (UsersPermissions, error) {
+	if mock.expectedPermissions != nil || mock.expectedError != nil {
+		return UsersPermissions{userID: mock.expectedPermissions}, mock.expectedError
+	}
+	return UsersPermissions{userID: Permissions{userID: Allowed}}, nil
+}
+
 func (mock *GatekeeperMock) SetPermissions(userID, groupID string, permissions Permissions) (Permissions, error) {
 	return Permissions{userID: Allowed}, nil
 }

--- a/clients/mocks_test.go
+++ b/clients/mocks_test.go
@@ -78,6 +78,7 @@ func TestGatekeeperMock_GroupsForUser(t *testing.T) {
 	for _, user := range gkc.UserIDs {
 		expectedPerms[user] = mockedPerms
 	}
+	expectedPerms[GROUPID] = Permissions{"root": Allowed}
 	if userPerms, err := gkc.GroupsForUser(GROUPID); err != nil {
 		t.Fatal("No error should be returned")
 	} else if !reflect.DeepEqual(userPerms, expectedPerms) {

--- a/clients/mocks_test.go
+++ b/clients/mocks_test.go
@@ -10,7 +10,7 @@ import (
 const USERID, GROUPID, TOKEN_MOCK = "123user", "456group", "this is a token"
 
 func makeExpectedPermissons() Permissions {
-	return Permissions{USERID: Allowed}
+	return Permissions{"root": Allowed}
 }
 
 func makeExpectedUsersPermissions() UsersPermissions {

--- a/clients/mocks_test.go
+++ b/clients/mocks_test.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -52,6 +53,37 @@ func TestGatekeeperMock_GroupsForUser(t *testing.T) {
 	} else if !reflect.DeepEqual(perms, expected) {
 		t.Fatalf("Perms were [%v] but expected [%v]", perms, expected)
 	}
+
+	// testing with error
+	gkc.SetExpected(nil, errors.New("gk error"))
+	if _, err := gkc.GroupsForUser(GROUPID); err == nil {
+		t.Fatal("An error should be returned")
+	}
+
+	// testing with permisson set
+	mockedPerms := Permissions{"view": Allowed, "root": Allowed}
+	gkc.SetExpected(mockedPerms, nil)
+	expectedPerms := UsersPermissions{}
+	expectedPerms[GROUPID] = mockedPerms
+	if perms, err := gkc.GroupsForUser(GROUPID); err != nil {
+		t.Fatal("No error should be returned")
+	} else if !reflect.DeepEqual(perms, expectedPerms) {
+		t.Fatalf("Perms were [%v] but expected [%v]", perms, expectedPerms)
+	}
+
+	//testing with UserIds
+	gkc.SetExpected(mockedPerms, nil)
+	gkc.UserIDs = []string{"user1", "user2"}
+	expectedPerms = UsersPermissions{}
+	for _, user := range gkc.UserIDs {
+		expectedPerms[user] = mockedPerms
+	}
+	if userPerms, err := gkc.GroupsForUser(GROUPID); err != nil {
+		t.Fatal("No error should be returned")
+	} else if !reflect.DeepEqual(userPerms, expectedPerms) {
+		t.Fatalf("Perms were [%v] but expected [%v]", userPerms, expectedPerms)
+	}
+
 }
 func TestGatekeeperMock_SetPermissions(t *testing.T) {
 

--- a/clients/mocks_test.go
+++ b/clients/mocks_test.go
@@ -43,6 +43,16 @@ func TestGatekeeperMock_UsersInGroup(t *testing.T) {
 	}
 }
 
+func TestGatekeeperMock_GroupsForUser(t *testing.T) {
+	expected := makeExpectedUsersPermissions()
+
+	gkc := NewGatekeeperMock(nil, nil)
+	if perms, err := gkc.GroupsForUser(GROUPID); err != nil {
+		t.Fatal("No error should be returned")
+	} else if !reflect.DeepEqual(perms, expected) {
+		t.Fatalf("Perms were [%v] but expected [%v]", perms, expected)
+	}
+}
 func TestGatekeeperMock_SetPermissions(t *testing.T) {
 
 	gkc := NewGatekeeperMock(nil, nil)

--- a/clients/shoreline/shorelineMock.go
+++ b/clients/shoreline/shorelineMock.go
@@ -5,11 +5,19 @@ import (
 )
 
 type ShorelineMockClient struct {
-	ServerToken string
+	ServerToken  string
+	Unauthorized bool
+	UserID       string
+	IsServer     bool
 }
 
 func NewMock(token string) *ShorelineMockClient {
-	return &ShorelineMockClient{ServerToken: token}
+	return &ShorelineMockClient{
+		ServerToken:  token,
+		Unauthorized: false,
+		UserID:       "123.456.789",
+		IsServer:     true,
+	}
 }
 
 func (client *ShorelineMockClient) Start() error {
@@ -22,15 +30,18 @@ func (client *ShorelineMockClient) Close() {
 }
 
 func (client *ShorelineMockClient) Login(username, password string) (*UserData, string, error) {
-	return &UserData{UserID: "123.456.789", Username: username, Emails: []string{username}}, client.ServerToken, nil
+	return &UserData{UserID: client.UserID, Username: username, Emails: []string{username}}, client.ServerToken, nil
 }
 
 func (client *ShorelineMockClient) Signup(username, password, email string) (*UserData, error) {
-	return &UserData{UserID: "123.xxx.456", Username: username, Emails: []string{email}}, nil
+	return &UserData{UserID: client.UserID, Username: username, Emails: []string{email}}, nil
 }
 
 func (client *ShorelineMockClient) CheckToken(token string) *TokenData {
-	return &TokenData{UserID: "987.654.321", IsServer: true}
+	if client.Unauthorized {
+		return nil
+	}
+	return &TokenData{UserID: client.UserID, IsServer: client.IsServer}
 }
 
 func (client *ShorelineMockClient) TokenProvide() string {

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
In order to check that a guest is authorized to view the data of multiple patients, we need to implement the missing gatekeeper route(i.e. GET /access/groups/:userid) in the client.