### PR TITLE
YLP-1644: Use a new env var to load a custom CA for SSL connections to auth0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Go-Common is the library of common functions for Tidepool's Go-based applications
 
+## 1.4.1 - 2022-06-29
+### Engineering
+- YLP-1644: possibility to set a custom CA cert for when we run backloops in our dev/test env
+
 ## 1.4.0 - 2022-06-03
 ### Added
 - Add setCollection method to seagull client


### PR DESCRIPTION
possibility to set a custom CA cert for when we run backloops in our dev/test env